### PR TITLE
fix: cosign-installer to use version 3.5.0

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -40,7 +40,7 @@ jobs:
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v3.5.05
+        uses: sigstore/cosign-installer@v3.5.0
         with:
           cosign-release: 'v2.3.0'
 


### PR DESCRIPTION
I did a small typo on the last PR, this should fix it and make the GH Action work again 👍 