### PR TITLE
Update proxy to handle uploads and forward the rest of requests

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -92,4 +92,5 @@ jobs:
           COSIGN_EXPERIMENTAL: "true"
         # This step uses the identity token to provision an ephemeral certificate
         # against the sigstore community Fulcio instance.
-        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}
+        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign --yes {}@${{ steps.build-and-push.outputs.digest }}
+        

--- a/README.md
+++ b/README.md
@@ -19,13 +19,11 @@ In docker compose, you can use it like this (if you only want it to be exposed w
         environment:
           - IMG_MAX_WIDTH=1920
           - IMG_MAX_HEIGHT=1080
-          - FORWARD_DESTINATION=http://immich-server:3001/asset/upload
+          - FORWARD_DESTINATION=http://immich-server:3001/api/assets
           - FILE_UPLOAD_FIELD=assetData
-          - LISTEN_PATH=/api/asset/upload
         restart: always
 
 If you use existing software, it might be needed to intercept incoming connections and redirect them to this proxy. You can do this via Cloudflare tunnels or via a front-facing reverse proxy/webserver.
-
 
 
 ## Environment variables
@@ -38,5 +36,4 @@ If you use existing software, it might be needed to intercept incoming connectio
 |`IMG_MAX_PIXELS`|2073600|If the images width*height (in pixels) doesn't exceed this value, don't resize
 |`FORWARD_DESTINATION`|https://httpbin.org/post|Where should the result be sent to
 |`FILE_UPLOAD_FIELD`|assetData|Name of the file field to potentially resize
-|`LISTEN_PATH`|/upload|Path used to process file uploads
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ In docker compose, you can use it like this (if you only want it to be exposed w
           - IMG_MAX_HEIGHT=1080
           - FORWARD_DESTINATION=http://immich-server:3001/api/assets
           - FILE_UPLOAD_FIELD=assetData
+          - LISTEN_PATH=/api/assets
         restart: always
 
 If you use existing software, it might be needed to intercept incoming connections and redirect them to this proxy. You can do this via Cloudflare tunnels or via a front-facing reverse proxy/webserver.
@@ -36,4 +37,5 @@ If you use existing software, it might be needed to intercept incoming connectio
 |`IMG_MAX_PIXELS`|2073600|If the images width*height (in pixels) doesn't exceed this value, don't resize
 |`FORWARD_DESTINATION`|https://httpbin.org/post|Where should the result be sent to
 |`FILE_UPLOAD_FIELD`|assetData|Name of the file field to potentially resize
+|`LISTEN_PATH`|/api/assets|Path used to process file uploads
 


### PR DESCRIPTION
Since v1.106.1 Immich uses a POST on /api/assets to upload files, but also a PUT to update them and a DELETE to delete them. So for example right now if you try to delete an image you get a 400 Bad Request. That's mainly because this upload proxy procces everything on the listen path so it now breaks some features of the Immich website.

I've already played a little bit with the tunnel configuration but it's quite imposible to solve with actual code, as it does not distinguish a POST from a PUT or a DELETE so everything gets treated the same way and for example the DELETE fails when the code [tries to get a field](https://github.com/JamesCullum/multipart-upload-proxy/blob/8f642a0d71b89b999031a181d841d6d648cabd71/proxy.go#L123) from a [request](https://v1.106.1.archive.immich.app/docs/api/delete-assets) that does not have it.

Almost all code changes have a comment so you can understand why I did hardcode some variables. You can test this image if you pull from --> ghcr.io/hamzab70/multipart-upload-proxy:main

That's why with this changes and configuring the cloudflare tunnel as the attached image you should be able to make it work again 😄.

![image](https://github.com/user-attachments/assets/96be896d-aa55-4da0-a942-e22891c756e1)
